### PR TITLE
Fixes edge case in test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "react-hooks-jsx-lab",
       "version": "0.1.0",
       "dependencies": {
         "react": "^17.0.1",

--- a/src/__tests__/About.test.js
+++ b/src/__tests__/About.test.js
@@ -14,10 +14,9 @@ test("renders a <div> with three children", () => {
 });
 
 test("renders a <h2> with the text 'About Me'", () => {
-  render(<About />);
-  const h2 = screen.queryByText(/about me/i);
-  expect(h2).toBeInTheDocument();
-  expect(h2.tagName).toEqual("H2");
+  const { container } = render(<About />);
+  const h2 = container.querySelector("h2");
+  expect(h2.textContent).toEqual("About Me");
 });
 
 test("renders a <p> element", () => {


### PR DESCRIPTION
- Fixes #5 

The `<About>` component should allow users to include a `<p>` tag with
any arbitrary text content. When the content includes a string of "about me",
this matched the selector for the `<h2>` element instead. Updated
tests to search for element using a query selector rather than text content
in order to get around this issue.

Thanks @LNKeat for flagging!